### PR TITLE
Topic/periodic sync

### DIFF
--- a/.testr.conf
+++ b/.testr.conf
@@ -1,0 +1,4 @@
+[DEFAULT]
+test_command=${PYTHON:-python} -m subunit.run discover -t ./ ${OS_TEST_PATH:-./networking_bigswitch_l3_pe/tests/unit} $LISTOPT $IDOPTION
+test_id_option=--load-list $IDFILE
+test_list_option=--list

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ periodically does the following:
         interface tenant system
     tenant system
       logical-router
-        interface tenant admin.openstack
+        interface tenant project_example.openstack
    ```
    * When adding a subnet, the plugin adds the following configurations.
    ```
@@ -40,6 +40,26 @@ You can install the plugin by executing the following command.
 
 How to use
 ----------
+Before enabling the plugin in neutron-server, You can execute bcf-sync-l3
+command to check what the plugin will do.
+
+    $ cd /path/to/networking_bigswitch_l3_pe
+    # This is dry run mode. You can check what bcf-sync-l3 will do.
+    $ sudo PYTHONPATH=.. ./bin/bcf-sync-l3
+    No handlers could be found for logger "oslo_config.cfg"
+    2016-11-22 17:38:38,388 - networking_bigswitch_l3_pe.lib.synchronizer - INFO - This is dry run mode.
+    2016-11-22 17:38:38,388 - networking_bigswitch_l3_pe.lib.synchronizer - INFO - Start synchronization: events=None
+    2016-11-22 17:38:38,596 - networking_bigswitch_l3_pe.lib.synchronizer - DEBUG - exclude_networks=[]
+    2016-11-22 17:38:38,596 - networking_bigswitch_l3_pe.lib.synchronizer - INFO - Adding networks: [{'project_name': u'project_example.openstack', 'segment_name': u'net_example'}]
+    2016-11-22 17:38:38,597 - networking_bigswitch_l3_pe.lib.synchronizer - INFO - Finished synchronization(dry run mode): synchronized resources: {'added': {'network': [{'project_name': u'project_example.openstack', 'segment_name': u'net_example'}]}}.
+    # If there is no problem, You can run bcf-sync-l3 in execution mode.
+    $ sudo PYTHONPATH=.. ./bin/bcf-sync-l3  -x
+    No handlers could be found for logger "oslo_config.cfg"
+    2016-11-22 17:38:42,529 - networking_bigswitch_l3_pe.lib.synchronizer - INFO - Start synchronization: events=None
+    2016-11-22 17:38:42,724 - networking_bigswitch_l3_pe.lib.synchronizer - DEBUG - exclude_networks=[]
+    2016-11-22 17:38:42,725 - networking_bigswitch_l3_pe.lib.synchronizer - INFO - Adding networks: [{'project_name': u'project_example.openstack', 'segment_name': u'net_example'}]
+    2016-11-22 17:38:43,287 - networking_bigswitch_l3_pe.lib.synchronizer - INFO - Finished synchronization: synchronized resources: {'added': {'network': [{'project_name': u'project_example.openstack', 'segment_name': u'net_example'}]}}.
+
 You can enable the plugin as the Neutron mechanism_drivers with bsn_ml2 plugin
 in ```/etc/neutron/plugins/ml2/ml2_conf.ini```.
 
@@ -56,5 +76,5 @@ You can configure these parameters.
 The plugin uses these parameters in restproxy section.
 
     [restproxy]
-    server_auth = admin:password
+    server_auth = user:password
     neutron_id = neutron_name

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ You can configure these parameters.
     [networking_bigswitch_l3_pe]
     api_url = https://<bcf_controller>:8443/api/v1
     sync_interval = 600
+    exclude_physical_networks = physnet2
 
 The plugin uses these parameters in restproxy section.
 

--- a/README.md
+++ b/README.md
@@ -5,14 +5,32 @@ This is the OpenStack Neutron ML2 Driver for Big Cloud Fabric Physical Edition.
 
 What the plugin does
 --------------------
-The plugin syncs logical routers with BCF Physical Edition. Specifically, the plugin does the following:
+The plugin synchronizes networks and subnets in OpenStack with BCF. The plugin
+periodically does the following:
 
- * When a network is created in OpenStack, the plugin creates tenant interfaces and
-   a segment interface and adds a static route to the system tenant.
-   When the network is deleted, the plugin deletes them.
- * When a subnet is created in OpenStack, the plugin assigns the gateway ip address
-   to the segment interface.
-   When the subnet is deleted, the plugin remove the address from the interface.
+ * The plugin checks if configurations related to networks and subnets in OpenStack
+   exist in BCF. If configurations don't exist, the plugin adds them to BCF.
+   * When adding a network, the plugin adds the following configurations.
+   ```
+    tenant project_example.openstack
+      logical-router
+        route 0.0.0.0/0 next-hop tenant system
+        interface segment net_example
+        interface tenant system
+    tenant system
+      logical-router
+        interface tenant admin.openstack
+   ```
+   * When adding a subnet, the plugin adds the following configurations.
+   ```
+    tenant project_example.openstack
+      logical-router
+        interface segment net_example
+          ip address 10.0.0.1/24
+   ```
+ * The plugin checks if networks and subnets related to BCF configurations exist
+   in OpenStack. If networks and subnets don't exist, the plugin removes the
+   configurations from BCF.
 
 How to install
 --------------
@@ -22,15 +40,17 @@ You can install the plugin by executing the following command.
 
 How to use
 ----------
-You can enable the plugin as the Neutron mechanism_drivers with bsn_ml2 plugin in ```/etc/neutron/plugins/ml2/ml2_conf.ini```.
+You can enable the plugin as the Neutron mechanism_drivers with bsn_ml2 plugin
+in ```/etc/neutron/plugins/ml2/ml2_conf.ini```.
 
     [ml2]
     mechanism_drivers = bsn_ml2,networking_bigswitch_l3_pe
 
-The BCF API URL should be configured as follows.
+You can configure these parameters.
 
     [networking_bigswitch_l3_pe]
-    api_url  = https://<bcf_controller>:8443/api/v1
+    api_url = https://<bcf_controller>:8443/api/v1
+    sync_interval = 600
 
 The plugin uses these parameters in restproxy section.
 

--- a/networking_bigswitch_l3_pe/bin/bcf-api
+++ b/networking_bigswitch_l3_pe/bin/bcf-api
@@ -1,0 +1,78 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+""" bcf api cli
+# GET
+$ ./bcf-api /data/controller/applications/bcf/tenant
+$ ./bcf-api /data/controller/applications/bcf/tenant[name=\"system\"]
+
+# PUT with -d option
+$ ./bcf-api /data/controller/applications/bcf/tenant[name=\"system\"]/\
+  logical-router/policy-list[name=\"policy_test02\"] \
+  -m PUT -d '{"name": "policy_test02"}'
+# PUT with -j option
+$ cat policy_test02.json
+{ "name" : "policy_test02" }
+$ ./bcf-api /data/controller/applications/bcf/tenant[name=\"system\"]/\
+  logical-router/policy-list[name=\"policy_test02\"] \
+  -m PUT -j policy_test02.json
+
+# PATCH
+$ ./bcf-api /data/controller/applications/bcf/tenant[name=\"system\"]/\
+  logical-router \
+  -m PATCH -d '{"inound-policy": "policy_test02"}'
+
+# DELETE
+$ ./bcf-api /data/controller/applications/bcf/tenant[name=\"system\"]/\
+  logical-router/policy-list[name=\"policy_test02\"] -m DELETE
+"""
+
+import json
+import argparse
+from oslo_config import cfg
+from neutron.common import config
+import bsnstacklib.plugins.bigswitch.config
+import networking_bigswitch_l3_pe.lib.config
+from networking_bigswitch_l3_pe.lib.rest_client import RestClient
+import inspect
+
+
+def setup_config():
+    bsnstacklib.plugins.bigswitch.config.register_config()
+    networking_bigswitch_l3_pe.lib.config.register_config()
+    config.init(['--config-file=/etc/neutron/neutron.conf',
+                 '--config-file=/etc/neutron/plugins/ml2/ml2_conf.ini'])
+
+
+def main():
+    parser = argparse.ArgumentParser(description='bcf api cli')
+    parser.add_argument('uri')  # like 'core/version/appliance'
+    parser.add_argument('-m', '--method', default='GET')
+    parser.add_argument('-d', '--data', default='{}')
+    parser.add_argument('-j', '--json', default='')
+    parser.add_argument('-p', '--param', default=None)
+    parser.add_argument('-v', '--verbose', action='store_true', default=False)
+    args = parser.parse_args()
+
+    setup_config()
+
+    api_url = cfg.CONF.networking_bigswitch_l3_pe.api_url
+    username, password = cfg.CONF.RESTPROXY.server_auth.split(':')
+    client = RestClient(api_url, username, password)
+
+    try:
+        if args.json:
+            f = open(args.json, 'r')
+            data = json.dumps(json.load(f))
+        else:
+            data = args.data
+        uri = args.uri
+        verb = args.method
+        param = args.param
+        code, output = client.rest_call(uri, data, verb=verb, param=param)
+        print output
+    except Exception as e:
+        print inspect.getmembers(e)
+
+if __name__ == '__main__':
+    main()

--- a/networking_bigswitch_l3_pe/bin/bcf-sync-l3
+++ b/networking_bigswitch_l3_pe/bin/bcf-sync-l3
@@ -45,7 +45,7 @@ def setup_config():
 
 
 def main():
-    parser = argparse.ArgumentParser(description='bcf api cli')
+    parser = argparse.ArgumentParser(description='synchronize l3 config with BCF')
     parser.add_argument('-x', '--execute', action='store_true', default=False)
     args = parser.parse_args()
 

--- a/networking_bigswitch_l3_pe/bin/sync-l3
+++ b/networking_bigswitch_l3_pe/bin/sync-l3
@@ -56,8 +56,10 @@ def main():
     api_url = cfg.CONF.networking_bigswitch_l3_pe.api_url
     username, password = cfg.CONF.RESTPROXY.server_auth.split(':')
     neutron_id = cfg.CONF.RESTPROXY.neutron_id
-    sync = Synchronizer(api_url, username, password,
-                        neutron_id, dry_run=(not args.execute))
+    exclude_physical_networks = \
+        cfg.CONF.networking_bigswitch_l3_pe.exclude_physical_networks
+    sync = Synchronizer(api_url, username, password, neutron_id,
+                        exclude_physical_networks, dry_run=(not args.execute))
     sync.synchronize()
 
 if __name__ == '__main__':

--- a/networking_bigswitch_l3_pe/bin/sync-l3
+++ b/networking_bigswitch_l3_pe/bin/sync-l3
@@ -1,0 +1,64 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+# Copyright 2016 DeNA Co., Ltd.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import logging
+import argparse
+from oslo_config import cfg
+from neutron.common import config
+import keystoneclient.middleware.auth_token
+import bsnstacklib.plugins.bigswitch.config
+import networking_bigswitch_l3_pe.lib.config
+from networking_bigswitch_l3_pe.lib.synchronizer import Synchronizer
+
+LOG = logging.getLogger('networking_bigswitch_l3_pe.lib.synchronizer')
+
+
+def enable_stdout_log(logger):
+    import sys
+    logger.setLevel(logging.DEBUG)
+    ch = logging.StreamHandler(sys.stdout)
+    formatter = logging.Formatter(
+                '%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+    ch.setFormatter(formatter)
+    logger.addHandler(ch)
+
+
+def setup_config():
+    bsnstacklib.plugins.bigswitch.config.register_config()
+    networking_bigswitch_l3_pe.lib.config.register_config()
+    config.init(['--config-file=/etc/neutron/neutron.conf',
+                 '--config-file=/etc/neutron/plugins/ml2/ml2_conf.ini'])
+
+
+def main():
+    parser = argparse.ArgumentParser(description='bcf api cli')
+    parser.add_argument('-x', '--execute', action='store_true', default=False)
+    args = parser.parse_args()
+
+    enable_stdout_log(LOG)
+    # XXX: No handlers could be found for logger "oslo_config.cfg"
+    setup_config()
+
+    api_url = cfg.CONF.networking_bigswitch_l3_pe.api_url
+    username, password = cfg.CONF.RESTPROXY.server_auth.split(':')
+    neutron_id = cfg.CONF.RESTPROXY.neutron_id
+    sync = Synchronizer(api_url, username, password,
+                        neutron_id, dry_run=(not args.execute))
+    sync.synchronize()
+
+if __name__ == '__main__':
+    main()

--- a/networking_bigswitch_l3_pe/drivers/mech.py
+++ b/networking_bigswitch_l3_pe/drivers/mech.py
@@ -14,13 +14,10 @@
 
 import bsnstacklib.plugins.bigswitch.config
 import logging
-from neutron import context as ncontext
-from neutron.db import db_base_plugin_v2
+import eventlet
 from neutron.plugins.ml2.driver_api import MechanismDriver
 import networking_bigswitch_l3_pe.lib.config
-from networking_bigswitch_l3_pe.lib.exceptions import UpdateNetworkNameError
-from networking_bigswitch_l3_pe.lib.keystone_client import KeystoneClient
-from networking_bigswitch_l3_pe.lib.rest_client import RestClient
+from networking_bigswitch_l3_pe.lib.synchronizer import Synchronizer
 from oslo_config import cfg
 LOG = logging.getLogger(__name__)
 
@@ -33,85 +30,19 @@ class BCFPhysicalEditionMechanismDriver(MechanismDriver):
 
         api_url = cfg.CONF.networking_bigswitch_l3_pe.api_url
         username, password = cfg.CONF.RESTPROXY.server_auth.split(':')
-        self.neutron_id = cfg.CONF.RESTPROXY.neutron_id
+        neutron_id = cfg.CONF.RESTPROXY.neutron_id
+        self.sync = Synchronizer(api_url, username, password, neutron_id)
 
-        self.client = RestClient(api_url, username, password)
-        self.keystone_client = KeystoneClient()
-        self.db_plugin = db_base_plugin_v2.NeutronDbPluginV2()
+        eventlet.spawn(self._bcf_sync,
+                       cfg.CONF.networking_bigswitch_l3_pe.sync_interval)
+
+    def _bcf_sync(self, polling_interval=600):
+        while True:
+            try:
+                eventlet.sleep(polling_interval)
+                self.sync.synchronize()
+            except Exception as e:
+                LOG.exception("Excpetion in _bcf_sync: %(e)s", {'e': e})
 
     def initialize(self):
         pass
-
-    def create_network_postcommit(self, context):
-        project_name = self._get_project_name(context.current['tenant_id'])
-        segment_name = context.current['name']
-        self.client.create_net(project_name, segment_name)
-
-    def update_network_precommit(self, context):
-        self._validate_network_update(context)
-
-    def delete_network_postcommit(self, context):
-        project_name = self._get_project_name(context.current['tenant_id'])
-        segment_name = context.current['name']
-        self.client.delete_net(project_name, segment_name)
-
-    def create_subnet_postcommit(self, context):
-        project_name = self._get_project_name(context.current['tenant_id'])
-        segment_name = self._get_segment_name(context.current['network_id'])
-        gateway_ip = self._get_gateway_ip(context.current)
-        if gateway_ip:
-            self.client.create_subnet(project_name, segment_name, gateway_ip)
-        else:
-            LOG.debug("gateway_ip is not defined in segment(%(segment_name)s)"
-                      " of tenant(%(tenant_name)s)",
-                      {'tenant_name': project_name,
-                       'segment_name': segment_name})
-
-    def update_subnet_postcommit(self, context):
-        project_name = self._get_project_name(context.current['tenant_id'])
-        segment_name = self._get_segment_name(context.current['network_id'])
-        current_gateway_ip = self._get_gateway_ip(context.current)
-        original_gateway_ip = self._get_gateway_ip(context.original)
-        if current_gateway_ip == original_gateway_ip:
-            return
-        if current_gateway_ip:
-            self.client.update_subnet(project_name, segment_name,
-                                      original_gateway_ip, current_gateway_ip)
-        else:
-            self.client.delete_subnet(project_name, segment_name,
-                                      original_gateway_ip)
-
-    def delete_subnet_postcommit(self, context):
-        project_name = self._get_project_name(context.current['tenant_id'])
-        segment_name = self._get_segment_name(context.current['network_id'])
-        gateway_ip = self._get_gateway_ip(context.current)
-        if gateway_ip:
-            self.client.delete_subnet(project_name, segment_name, gateway_ip)
-        else:
-            LOG.debug("gateway_ip is not defined in segment(%(segment_name)s)"
-                      " of tenant(%(tenant_name)s)",
-                      {'tenant_name': project_name,
-                       'segment_name': segment_name})
-
-    def _get_project_name(self, tenant_id):
-        projects = self.keystone_client.get_projects()
-        LOG.debug("project: id=%(project_id)s, name=%(name)s",
-                  {'project_id': tenant_id, 'name': projects[tenant_id]})
-        return projects[tenant_id] + "." + self.neutron_id
-
-    def _get_segment_name(self, network_id):
-        ctx = ncontext.get_admin_context()
-        net = self.db_plugin.get_network(ctx, network_id)
-        LOG.debug("network: id=%(network_id)s, name=%(name)s",
-                  {'network_id': network_id, 'name': net['name']})
-        return net['name']
-
-    def _get_gateway_ip(self, current):
-        if current['gateway_ip']:
-            return current['gateway_ip'] + '/' + current['cidr'].split('/')[1]
-        else:
-            return None
-
-    def _validate_network_update(self, context):
-        if context.current['name'] != context.original['name']:
-            raise UpdateNetworkNameError()

--- a/networking_bigswitch_l3_pe/drivers/mech.py
+++ b/networking_bigswitch_l3_pe/drivers/mech.py
@@ -16,9 +16,17 @@ import bsnstacklib.plugins.bigswitch.config
 import logging
 import eventlet
 from neutron.plugins.ml2.driver_api import MechanismDriver
+from neutron.db import db_base_plugin_v2
 import networking_bigswitch_l3_pe.lib.config
 from networking_bigswitch_l3_pe.lib.synchronizer import Synchronizer
+from networking_bigswitch_l3_pe.lib.event import EventWatcher
+from networking_bigswitch_l3_pe.lib.event import EventNotifier
+from networking_bigswitch_l3_pe.lib.event import EVENT_NETWORK_DELETE
+from networking_bigswitch_l3_pe.lib.event import EVENT_SUBNET_DELETE
+from networking_bigswitch_l3_pe.lib.keystone_client import KeystoneClient
 from oslo_config import cfg
+from neutron import context as ncontext
+
 LOG = logging.getLogger(__name__)
 
 
@@ -30,9 +38,17 @@ class BCFPhysicalEditionMechanismDriver(MechanismDriver):
 
         api_url = cfg.CONF.networking_bigswitch_l3_pe.api_url
         username, password = cfg.CONF.RESTPROXY.server_auth.split(':')
-        neutron_id = cfg.CONF.RESTPROXY.neutron_id
-        self.sync = Synchronizer(api_url, username, password, neutron_id)
+        self.neutron_id = cfg.CONF.RESTPROXY.neutron_id
+        exclude_physical_networks = \
+            cfg.CONF.networking_bigswitch_l3_pe.exclude_physical_networks
+        self.sync = Synchronizer(api_url, username, password, self.neutron_id,
+                                 exclude_physical_networks)
+        self.notifier = EventNotifier()
+        self.watcher = EventWatcher()
+        self.keystone_client = KeystoneClient()
+        self.db_plugin = db_base_plugin_v2.NeutronDbPluginV2()
 
+        eventlet.spawn(self.watcher.watch)
         eventlet.spawn(self._bcf_sync,
                        cfg.CONF.networking_bigswitch_l3_pe.sync_interval)
 
@@ -40,9 +56,43 @@ class BCFPhysicalEditionMechanismDriver(MechanismDriver):
         while True:
             try:
                 eventlet.sleep(polling_interval)
-                self.sync.synchronize()
+                events = self.watcher.pop_events()
+                self.sync.synchronize(events=events)
             except Exception as e:
                 LOG.exception("Excpetion in _bcf_sync: %(e)s", {'e': e})
 
     def initialize(self):
         pass
+
+    def delete_network_postcommit(self, context):
+        project_name = self._get_project_name(context.current['tenant_id'])
+        segment_name = context.current['name']
+        self.notifier.notify(context.current, EVENT_NETWORK_DELETE, {
+            'project_name': project_name,
+            'segment_name': segment_name,
+        })
+
+    def delete_subnet_postcommit(self, context):
+        project_name = self._get_project_name(context.current['tenant_id'])
+        segment_name = self._get_segment_name(context.current['network_id'])
+        gateway_ip = self._get_gateway_ip(context.current)
+        self.notifier.notify(context.current, EVENT_SUBNET_DELETE, {
+            'project_name': project_name,
+            'segment_name': segment_name,
+            'current_gateway_ip': gateway_ip,
+        })
+
+    def _get_project_name(self, tenant_id):
+        projects = self.keystone_client.get_projects()
+        return projects[tenant_id] + "." + self.neutron_id
+
+    def _get_segment_name(self, network_id):
+        ctx = ncontext.get_admin_context()
+        net = self.db_plugin.get_network(ctx, network_id)
+        return net['name']
+
+    def _get_gateway_ip(self, current):
+        if current['gateway_ip']:
+            return current['gateway_ip'] + '/' + current['cidr'].split('/')[1]
+        else:
+            return None

--- a/networking_bigswitch_l3_pe/drivers/mech.py
+++ b/networking_bigswitch_l3_pe/drivers/mech.py
@@ -13,19 +13,19 @@
 #    under the License.
 
 import bsnstacklib.plugins.bigswitch.config
-import logging
 import eventlet
-from neutron.plugins.ml2.driver_api import MechanismDriver
-from neutron.db import db_base_plugin_v2
+import logging
 import networking_bigswitch_l3_pe.lib.config
-from networking_bigswitch_l3_pe.lib.synchronizer import Synchronizer
-from networking_bigswitch_l3_pe.lib.event import EventWatcher
-from networking_bigswitch_l3_pe.lib.event import EventNotifier
 from networking_bigswitch_l3_pe.lib.event import EVENT_NETWORK_DELETE
 from networking_bigswitch_l3_pe.lib.event import EVENT_SUBNET_DELETE
+from networking_bigswitch_l3_pe.lib.event import EventNotifier
+from networking_bigswitch_l3_pe.lib.event import EventWatcher
 from networking_bigswitch_l3_pe.lib.keystone_client import KeystoneClient
-from oslo_config import cfg
+from networking_bigswitch_l3_pe.lib.synchronizer import Synchronizer
 from neutron import context as ncontext
+from neutron.db import db_base_plugin_v2
+from neutron.plugins.ml2.driver_api import MechanismDriver
+from oslo_config import cfg
 
 LOG = logging.getLogger(__name__)
 

--- a/networking_bigswitch_l3_pe/lib/config.py
+++ b/networking_bigswitch_l3_pe/lib/config.py
@@ -18,6 +18,8 @@ bcf_pe_opts = [
     cfg.StrOpt('api_url', default='https://localhost:8443/api/v1',
                help="A BCF REST API. This should be a fully qualified url "
                     "of the form (i.e. https://controller:8443/api/v1)"),
+    cfg.IntOpt('sync_interval', default=600,
+               help="Time between synchronization to BCF Controller "),
 ]
 
 

--- a/networking_bigswitch_l3_pe/lib/config.py
+++ b/networking_bigswitch_l3_pe/lib/config.py
@@ -20,6 +20,9 @@ bcf_pe_opts = [
                     "of the form (i.e. https://controller:8443/api/v1)"),
     cfg.IntOpt('sync_interval', default=600,
                help="Time between synchronization to BCF Controller "),
+    cfg.ListOpt('exclude_physical_networks', default=[],
+                help="A comma separated list of physical networks which "
+                     "should not be synchronized with BCF"),
 ]
 
 

--- a/networking_bigswitch_l3_pe/lib/event.py
+++ b/networking_bigswitch_l3_pe/lib/event.py
@@ -1,0 +1,79 @@
+# Copyright 2016 DeNA Co., Ltd.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import logging
+from oslo_config import cfg
+import oslo_messaging
+
+LOG = logging.getLogger(__name__)
+
+OSLO_TOPIC = 'networking_bigswitch_l3_pe'
+OSLO_NAMESPACE = 'networking_bigswitch_l3_pe'
+EVENT_NETWORK_DELETE = 'delete_network'
+EVENT_SUBNET_DELETE = 'delete_subnet'
+
+
+class EventWatcherEndpoint(object):
+    target = oslo_messaging.Target(namespace=OSLO_NAMESPACE)
+
+    def __init__(self, watcher):
+        self.watcher = watcher
+
+    def info(self, ctxt, event_type, payload):
+        event = {
+            'event_type': event_type,
+            'payload': payload,
+        }
+        self.watcher.events.append(event)
+        LOG.debug('recieved event: event_type=%(event_type)s, '
+                  'payload=%(payload)s, ctxt=%(ctxt)s',
+                  {'event_type': event_type,
+                   'payload': payload,
+                   'ctxt': ctxt})
+
+
+class EventWatcher(object):
+    def __init__(self):
+        self.events = []
+
+        transport = oslo_messaging.get_transport(cfg.CONF)
+        target = oslo_messaging.Target(topic=OSLO_TOPIC, server=cfg.CONF.host)
+        endpoints = [EventWatcherEndpoint(self)]
+        self.server = oslo_messaging.get_rpc_server(transport,
+                                                    target,
+                                                    endpoints)
+
+    def watch(self):
+        LOG.debug('start EventWatcher.watch()')
+        self.server.start()
+        self.server.wait()
+
+    def pop_events(self):
+        ret = self.events
+        self.events = []
+        return ret
+
+
+class EventNotifier(object):
+    def __init__(self):
+        transport = oslo_messaging.get_transport(cfg.CONF)
+        target = oslo_messaging.Target(topic=OSLO_TOPIC)
+        self.client = oslo_messaging.RPCClient(transport, target)
+
+    def notify(self, context, event_type, event):
+        cctxt = self.client.prepare(namespace=OSLO_NAMESPACE)
+        cctxt.cast(context, 'info', event_type=event_type, payload=event)
+        LOG.debug('notified event: event_type=%(event_type)s, event=%(event)s',
+                  {'event_type': event_type,
+                   'event': event})

--- a/networking_bigswitch_l3_pe/lib/keystone_client.py
+++ b/networking_bigswitch_l3_pe/lib/keystone_client.py
@@ -38,7 +38,7 @@ class KeystoneClient(object):
                 tenant_name=auth_tenant,
             )
         elif self.version == 'v3':
-            cfg.Error('keystone api v3 is not supported yet')
+            raise cfg.Error('keystone api v3 is not supported yet')
 
     def _get_api_version(self, auth_url):
         path = parse.urlparse(auth_url).path
@@ -51,5 +51,5 @@ class KeystoneClient(object):
         if self.version == 'v2':
             projects = self.keystone_client.tenants.list()
         elif self.version == 'v3':
-            cfg.Error('keystone api v3 is not supported yet')
+            raise cfg.Error('keystone api v3 is not supported yet')
         return {p.id: p.name for p in projects}

--- a/networking_bigswitch_l3_pe/lib/rest_client.py
+++ b/networking_bigswitch_l3_pe/lib/rest_client.py
@@ -14,8 +14,8 @@
 
 import json
 import logging
-from neutron.common import exceptions
 from networking_bigswitch_l3_pe.lib.exceptions import BCFRestError
+from neutron.common import exceptions
 import urllib
 import urllib2
 LOG = logging.getLogger(__name__)

--- a/networking_bigswitch_l3_pe/lib/rest_client.py
+++ b/networking_bigswitch_l3_pe/lib/rest_client.py
@@ -12,7 +12,6 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-import re
 import json
 import logging
 from neutron.common import exceptions
@@ -260,5 +259,13 @@ class RestClient(object):
         code, output = self.rest_call(SYSTEM_TENANT_IFS_PATH,
                                       json.dumps({}), verb='GET')
         ret = json.loads(output)
-        return [x for x in ret
-                if re.search(neutron_id, x['remote-tenant'])]
+        interfaces = []
+        for i in ret:
+            if 'remote-tenant' not in i:
+                continue
+            elems = i['remote-tenant'].rsplit('.', 1)
+            if len(elems) != 2:
+                continue
+            if elems[1] == neutron_id:
+                interfaces.append(i)
+        return interfaces

--- a/networking_bigswitch_l3_pe/lib/rest_client.py
+++ b/networking_bigswitch_l3_pe/lib/rest_client.py
@@ -12,6 +12,7 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+import re
 import json
 import logging
 from neutron.common import exceptions
@@ -43,6 +44,13 @@ IP_CIDR_PATH =\
 AAA_SESSION_PATH =\
     '/data/controller/core/aaa' +\
     '/session[auth-token="{session}"]'
+TENANTS_PATH =\
+    BASE_PATH +\
+    '/tenant[origination="{neutron_id}"]'
+SYSTEM_TENANT_IFS_PATH =\
+    BASE_PATH +\
+    '/tenant[name="system"]/logical-router/tenant-interface'
+LOG_STRING_LEN = 512
 
 
 class RestClient(object):
@@ -51,8 +59,9 @@ class RestClient(object):
         self.username = username
         self.password = password
         self.session_cookie = None
+        self.renew_session()
 
-    def _renew_session(self):
+    def renew_session(self):
         if self.session_cookie:
             self._destruct_session(self.session_cookie)
 
@@ -89,8 +98,11 @@ class RestClient(object):
         response = urllib2.urlopen(request)
         code = response.code
         result = response.read()
+        log_result = result
+        if len(result) > LOG_STRING_LEN:
+            log_result = result.replace("\n", "")[:LOG_STRING_LEN] + " ..."
         LOG.debug("code:%(code)s result:%(result)s",
-                  {'code': code, 'result': result})
+                  {'code': code, 'result': log_result})
         if code not in range(200, 300):
             raise BCFRestError(code=code, result=result,
                                method=verb, url=url, data=data)
@@ -111,8 +123,6 @@ class RestClient(object):
                        'segment_name': segment_name}
             LOG.debug(emsg)
             raise exceptions.InvalidInput(error_message=emsg)
-
-        self._renew_session()
 
         # create tenant-interface
         path = TENANT_IF_PATH.format(tenant='system',
@@ -152,8 +162,6 @@ class RestClient(object):
             LOG.debug(emsg)
             raise exceptions.InvalidInput(error_message=emsg)
 
-        self._renew_session()
-
         if not orig_ip_cidr:
             orig_ip_cidr = current_ip_cidr
 
@@ -179,8 +187,6 @@ class RestClient(object):
                        'segment_name': segment_name}
             LOG.debug(emsg)
             raise exceptions.InvalidInput(error_message=emsg)
-
-        self._renew_session()
 
         # delete segment interface
         path = SEGMENT_IF_PATH.format(tenant=tenant_name, segment=segment_name)
@@ -221,8 +227,6 @@ class RestClient(object):
             LOG.debug(emsg)
             raise exceptions.InvalidInput(error_message=emsg)
 
-        self._renew_session()
-
         # delete segment interface
         path = IP_CIDR_PATH.format(tenant=tenant_name,
                                    segment=segment_name,
@@ -230,3 +234,31 @@ class RestClient(object):
         self.rest_call(path, json.dumps({}), verb='DELETE')
 
         return True
+
+    def delete_system_tenant_interface(self, tenant_name):
+        if not tenant_name:
+            emsg = "Invalid parameter for delete_system_tenant_interface: "\
+                   "tenant_name=%(tenant_name)s" % {
+                       'tenant_name': tenant_name}
+            LOG.debug(emsg)
+            raise exceptions.InvalidInput(error_message=emsg)
+
+        # delete tenant-interface
+        path = TENANT_IF_PATH.format(tenant='system',
+                                     remote=tenant_name)
+        self.rest_call(path, json.dumps({}), verb='DELETE')
+
+        return True
+
+    def get_tenants(self, neutron_id):
+        path = TENANTS_PATH.format(neutron_id=neutron_id)
+        code, output = self.rest_call(path, json.dumps({}), verb='GET')
+        ret = json.loads(output)
+        return ret
+
+    def get_system_tenant_interfaces(self, neutron_id):
+        code, output = self.rest_call(SYSTEM_TENANT_IFS_PATH,
+                                      json.dumps({}), verb='GET')
+        ret = json.loads(output)
+        return [x for x in ret
+                if re.search(neutron_id, x['remote-tenant'])]

--- a/networking_bigswitch_l3_pe/lib/synchronizer.py
+++ b/networking_bigswitch_l3_pe/lib/synchronizer.py
@@ -1,0 +1,428 @@
+# Copyright 2016 DeNA Co., Ltd.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import logging
+import time
+from neutron.db import db_base_plugin_v2
+from neutron import context as ncontext
+from neutron.common import exceptions
+from networking_bigswitch_l3_pe.lib.rest_client import RestClient
+from networking_bigswitch_l3_pe.lib.keystone_client import KeystoneClient
+
+LOG = logging.getLogger(__name__)
+
+
+class Synchronizer(object):
+    def __init__(self, api_url, username, password, neutron_id, dry_run=False):
+        self.rest_client = RestClient(api_url, username, password)
+        self.keystone_client = KeystoneClient()
+        self.db_plugin = db_base_plugin_v2.NeutronDbPluginV2()
+        self.neutron_id = neutron_id
+        self.dry_run = dry_run
+        self.rest_sleep = 0.5
+
+    def _get_os_projects(self):
+        return self.keystone_client.get_projects()
+
+    def _get_os_networks(self):
+        ctx = ncontext.get_admin_context()
+        return self.db_plugin.get_networks(ctx)
+
+    def _get_os_subnets(self):
+        ctx = ncontext.get_admin_context()
+        return self.db_plugin.get_subnets(ctx)
+
+    def _exist_subnet(self, os, subnet, ip_cidr):
+        for s in os['subnets']:
+            gateway_ip = self._get_gateway_ip(s)
+            if s['id'] != subnet['id'] and \
+               s['tenant_id'] == subnet['tenant_id'] and \
+               s['network_id'] == subnet['network_id'] and \
+               gateway_ip == ip_cidr:
+                return s
+        return None
+
+    def _check_network_in_bcf(self, bcf, tenant_name, network_name):
+        matches = [t for t in bcf['tenants'] if t['name'] == tenant_name]
+        for m in matches:
+            if 'logical-router' in m and \
+               'tenant-interface' in m['logical-router'] and \
+               'segment-interface' in m['logical-router']:
+                for si in m['logical-router']['segment-interface']:
+                    if si['segment'] == network_name:
+                        return None
+        return {
+            'project_name': tenant_name,
+            'segment_name': network_name,
+        }
+
+    def _check_subnet_in_bcf(self, bcf, os,
+                             tenant_name, network_name, subnet):
+        gateway_ip = self._get_gateway_ip(subnet)
+        matches = [t for t in bcf['tenants'] if t['name'] == tenant_name]
+        for m in matches:
+            if not ('logical-router' in m and
+                    'tenant-interface' in m['logical-router'] and
+                    'segment-interface' in m['logical-router']):
+                continue
+
+            for si in m['logical-router']['segment-interface']:
+                if not (si['segment'] == network_name and
+                        'ip-subnet' in si):
+                    continue
+
+                for i in si['ip-subnet']:
+                    if 'ip-cidr' not in i:
+                        continue
+                    if i['ip-cidr'] == gateway_ip:
+                        # no change
+                        return None
+                    else:
+                        if not self._exist_subnet(os, subnet,
+                                                  i['ip-cidr']):
+                            # update subnet
+                            return {
+                                'project_name': tenant_name,
+                                'segment_name': network_name,
+                                'original_gateway_ip': i['ip-cidr'],
+                                'current_gateway_ip': gateway_ip,
+                            }
+        # add subnet
+        return {
+            'project_name': tenant_name,
+            'segment_name': network_name,
+            'current_gateway_ip': gateway_ip,
+        }
+
+    def _add_networks_to_bcf(self, networks):
+        if len(networks) > 0:
+            LOG.info("Adding networks: %(networks)s",
+                     {'networks': networks})
+        if self.dry_run:
+            return networks
+
+        ret = []
+        for n in networks:
+            if self.rest_client.create_net(n['project_name'],
+                                           n['segment_name']):
+                ret.append(n)
+            time.sleep(self.rest_sleep)
+
+        return ret
+
+    def _add_subnets_to_bcf(self, subnets):
+        if len(subnets) > 0:
+            LOG.info("Adding subnets: %(subnets)s",
+                     {'subnets': subnets})
+        if self.dry_run:
+            return subnets
+
+        ret = []
+        for s in subnets:
+            if ('original_gateway_ip' in s):
+                if self.rest_client.update_subnet(s['project_name'],
+                                                  s['segment_name'],
+                                                  s['original_gateway_ip'],
+                                                  s['current_gateway_ip']):
+                    ret.append(s)
+            else:
+                if self.rest_client.create_subnet(s['project_name'],
+                                                  s['segment_name'],
+                                                  s['current_gateway_ip']):
+                    ret.append(s)
+            time.sleep(self.rest_sleep)
+        return ret
+
+    def _delete_subnets_in_bcf(self, subnets):
+        if len(subnets) > 0:
+            LOG.info("Deleting subnets: %(subnets)s",
+                     {'subnets': subnets})
+        if self.dry_run:
+            return subnets
+
+        ret = []
+        for s in subnets:
+            if self.rest_client.delete_subnet(s['project_name'],
+                                              s['segment_name'],
+                                              s['current_gateway_ip']):
+                ret.append(s)
+            time.sleep(self.rest_sleep)
+        return ret
+
+    def _delete_networks_in_bcf(self, networks):
+        if len(networks) > 0:
+            LOG.info("Deleting networks: %(networks)s",
+                     {'networks': networks})
+        if self.dry_run:
+            return networks
+
+        ret = []
+        for n in networks:
+            if self.rest_client.delete_net(n['project_name'],
+                                           n['segment_name']):
+                ret.append(n)
+            time.sleep(self.rest_sleep)
+
+        return ret
+
+    def _delete_system_tenant_interfaces(self, interfaces):
+        if len(interfaces) > 0:
+            LOG.info("Deleting system tenant interfaces: %(interfaces)s",
+                     {'interfaces': interfaces})
+        if self.dry_run:
+            return interfaces
+
+        ret = []
+        for i in interfaces:
+            if self.rest_client.delete_system_tenant_interface(i):
+                ret.append(i)
+            time.sleep(self.rest_sleep)
+        return ret
+
+    def _find_project_in_os(self, os, tenant_name):
+        return next((p for p in os['projects']
+                     if (self._get_tenant_name(os, p)) ==
+                     tenant_name), None)
+
+    def _find_subnets_in_os(self, os, ip_cidr):
+        return [s for s in os['subnets'] if self._get_gateway_ip(s) == ip_cidr]
+
+    def _find_networks_in_os(self, os, segment_name):
+        return [n for n in os['networks'] if n['name'] == segment_name]
+
+    def _check_subnet_in_os(self, os, tenant):
+        ret = []
+        for si in tenant['logical-router']['segment-interface']:
+            if 'ip-subnet' not in si:
+                continue
+
+            for i in si['ip-subnet']:
+                if 'ip-cidr' not in i:
+                    continue
+
+                if self._find_subnets_in_os(os, i['ip-cidr']):
+                    continue
+
+                # Check if the project exists in OpenStack.
+                if self._find_project_in_os(os, tenant['name']):
+                    ret.append({
+                        'project_name': tenant['name'],
+                        'segment_name': si['segment'],
+                        'current_gateway_ip': i['ip-cidr'],
+                    })
+                else:
+                    # If doesn't exist, skip to delete the subnet.
+                    # In this case, the subnet will be deleted
+                    # by _update_tenant_cache() in bsnstacklib
+                    LOG.debug("project(%(project)s) of subnet(%(subnet)s) "
+                              "doesn't already exist in OpenStack.",
+                              {'project': tenant['name'],
+                               'subnet': i['ip-cidr']})
+
+        return ret
+
+    def _check_network_in_os(self, os, tenant):
+        ret = []
+        for si in tenant['logical-router']['segment-interface']:
+            if self._find_networks_in_os(os, si['segment']):
+                continue
+
+            # Check if the project exists in OpenStack.
+            if self._find_project_in_os(os, tenant['name']):
+                ret.append({
+                    'project_name': tenant['name'],
+                    'segment_name': si['segment'],
+                })
+            else:
+                # If doesn't exist, skip to delete the network.
+                # In this case, the network will be deleted
+                # by _update_tenant_cache() in bsnstacklib
+                LOG.debug("project(%(project)s) of network(%(network)s) "
+                          "doesn't already exist in OpenStack.",
+                          {'project': tenant['name'],
+                           'network': si['segment']})
+
+        return ret
+
+    def _get_gateway_ip(self, subnet):
+        if ('gateway_ip' not in subnet) or (not subnet['gateway_ip']):
+            emsg = "subnet(%(subnet_id)s) doensn't have gateway_ip" % {
+                       'subnet_id': subnet['id']}
+            LOG.debug(emsg)
+            raise exceptions.Invalid(error_message=emsg)
+
+        if ('cidr' not in subnet) or (not subnet['cidr']):
+            emsg = "subnet(%(subnet_id)s) doensn't have cidr" % {
+                       'subnet_id': subnet['id']}
+            LOG.debug(emsg)
+            raise exceptions.Invalid(error_message=emsg)
+
+        ip, mask = subnet['cidr'].split('/')
+        if not mask:
+            emsg = "cidr(%(cidr)s) of subnet(%(subnet_id)s)" \
+                   " is wrong format" % {
+                       'cidr': subnet['cidr'],
+                       'subnet_id': subnet['id']}
+            LOG.debug(emsg)
+            raise exceptions.Invalid(error_message=emsg)
+
+        return subnet['gateway_ip'] + '/' + mask
+
+    def _get_tenant_name(self, os, tenant_id):
+        if tenant_id not in os['projects']:
+            emsg = "tenant(%(tenant_id)s) is not found" % {
+                       'tenant_id': tenant_id}
+            LOG.debug(emsg)
+            raise exceptions.Invalid(error_message=emsg)
+
+        if not os['projects'][tenant_id]:
+            emsg = "tenant name(%(tenant_id)s) is empty" % {
+                       'tenant_id': tenant_id}
+            LOG.debug(emsg)
+            raise exceptions.Invalid(error_message=emsg)
+
+        return os['projects'][tenant_id] + '.' + self.neutron_id
+
+    def _get_network(self, os, network_id):
+        network = next((n for n in os['networks']
+                        if n['id'] == network_id), None)
+        if network:
+            return network
+        else:
+            emsg = "network(%(network_id)s) is not found" % {
+                       'network_id': network_id}
+            LOG.debug(emsg)
+            raise exceptions.Invalid(error_message=emsg)
+
+    def _add_resources(self, os, bcf):
+        networks = []
+        for n in os['networks']:
+            tenant_name = self._get_tenant_name(os, n['tenant_id'])
+            ret = self._check_network_in_bcf(bcf, tenant_name, n['name'])
+            if ret:
+                networks.append(ret)
+
+        subnets = []
+        for s in os['subnets']:
+            tenant_name = self._get_tenant_name(os, s['tenant_id'])
+            network = self._get_network(os, s['network_id'])
+            ret = self._check_subnet_in_bcf(bcf, os, tenant_name,
+                                            network['name'], s)
+            if ret:
+                subnets.append(ret)
+
+        networks = self._add_networks_to_bcf(networks)
+        subnets = self._add_subnets_to_bcf(subnets)
+
+        ret = {}
+        if len(networks) > 0:
+            ret['network'] = networks
+        if len(subnets) > 0:
+            ret['subnet'] = subnets
+        return ret
+
+    def _check_project_in_os(self, os, bcf, tenant_name):
+        project = self._find_project_in_os(os, tenant_name)
+        if project:
+            return None
+
+        # Check if the tenant doesn't exist in BCF.
+        tenant = next((t for t in bcf['tenants']
+                       if t['name'] == tenant_name), None)
+        if tenant:
+            LOG.info("tenant(%(tenant)s) still exists in BCF. "
+                     "skip to delete the system tenant interface.",
+                     {'tenant': tenant_name})
+            return None
+
+        return tenant_name
+
+    def _delete_resources(self, bcf, os):
+        subnets = []
+        networks = []
+        for t in bcf['tenants']:
+            if not ('logical-router' in t and
+                    'tenant-interface' in t['logical-router'] and
+                    'segment-interface' in t['logical-router']):
+                continue
+
+            ret = self._check_subnet_in_os(os, t)
+            if ret:
+                subnets.extend(ret)
+
+            ret = self._check_network_in_os(os, t)
+            if ret:
+                networks.extend(ret)
+
+        interfaces = []
+        for i in bcf['system_tenant_interfaces']:
+            ret = self._check_project_in_os(os, bcf, i['remote-tenant'])
+            if ret:
+                interfaces.append(i['remote-tenant'])
+
+        subnets = self._delete_subnets_in_bcf(subnets)
+        networks = self._delete_networks_in_bcf(networks)
+        interfaces = self._delete_system_tenant_interfaces(interfaces)
+
+        ret = {}
+        if len(subnets) > 0:
+            ret['subnets'] = subnets
+        if len(networks) > 0:
+            ret['networks'] = networks
+        if len(interfaces) > 0:
+            ret['system_tenant_interfaces'] = interfaces
+        return ret
+
+    def _get_bcf_resources(self):
+        tenants = self.rest_client.get_tenants(self.neutron_id)
+        system_tenant_interfaces =\
+            self.rest_client.get_system_tenant_interfaces(self.neutron_id)
+        return {
+            'tenants': tenants,
+            'system_tenant_interfaces': system_tenant_interfaces,
+        }
+
+    def _get_os_resources(self):
+        projects = self._get_os_projects()
+        networks = self._get_os_networks()
+        subnets = self._get_os_subnets()
+        return {
+            'projects': projects,
+            'networks': networks,
+            'subnets': subnets,
+        }
+
+    def synchronize(self):
+        LOG.info("Start synchronization")
+        self.rest_client.renew_session()
+
+        bcf = self._get_bcf_resources()
+        os = self._get_os_resources()
+
+        ret = {}
+        added = self._add_resources(os, bcf)
+        deleted = self._delete_resources(bcf, os)
+
+        if len(added) > 0:
+            ret['added'] = added
+        if len(deleted) > 0:
+            ret['deleted'] = deleted
+        if not self.dry_run:
+            if ret:
+                LOG.info("Finished synchronization: "
+                         "synchronized resources: %(resource)s.",
+                         {'resource': ret})
+            else:
+                LOG.info("Finished synchronization: Already synchronized.")
+        return ret

--- a/networking_bigswitch_l3_pe/lib/synchronizer.py
+++ b/networking_bigswitch_l3_pe/lib/synchronizer.py
@@ -13,13 +13,13 @@
 #    under the License.
 
 import logging
-import time
-from neutron.db import db_base_plugin_v2
-from neutron import context as ncontext
-from neutron.common import exceptions
-from networking_bigswitch_l3_pe.lib.rest_client import RestClient
 from networking_bigswitch_l3_pe.lib.keystone_client import KeystoneClient
+from networking_bigswitch_l3_pe.lib.rest_client import RestClient
+from neutron.common import exceptions
+from neutron import context as ncontext
+from neutron.db import db_base_plugin_v2
 from neutron.plugins.ml2 import models
+import time
 
 LOG = logging.getLogger(__name__)
 
@@ -254,13 +254,13 @@ class Synchronizer(object):
     def _get_gateway_ip(self, subnet):
         if ('gateway_ip' not in subnet) or (not subnet['gateway_ip']):
             emsg = "subnet(%(subnet_id)s) doensn't have gateway_ip" % {
-                       'subnet_id': subnet['id']}
+                   'subnet_id': subnet['id']}
             LOG.debug(emsg)
             raise exceptions.Invalid(message=emsg)
 
         if ('cidr' not in subnet) or (not subnet['cidr']):
             emsg = "subnet(%(subnet_id)s) doensn't have cidr" % {
-                       'subnet_id': subnet['id']}
+                   'subnet_id': subnet['id']}
             LOG.debug(emsg)
             raise exceptions.Invalid(message=emsg)
 
@@ -278,13 +278,13 @@ class Synchronizer(object):
     def _get_tenant_name(self, os, tenant_id):
         if tenant_id not in os['projects']:
             emsg = "tenant(%(tenant_id)s) is not found" % {
-                       'tenant_id': tenant_id}
+                   'tenant_id': tenant_id}
             LOG.debug(emsg)
             raise exceptions.Invalid(message=emsg)
 
         if not os['projects'][tenant_id]:
             emsg = "tenant name(%(tenant_id)s) is empty" % {
-                       'tenant_id': tenant_id}
+                   'tenant_id': tenant_id}
             LOG.debug(emsg)
             raise exceptions.Invalid(message=emsg)
 
@@ -293,13 +293,13 @@ class Synchronizer(object):
     def _get_tenant_id(self, os, tenant_id):
         if tenant_id not in os['projects']:
             emsg = "tenant(%(tenant_id)s) is not found" % {
-                       'tenant_id': tenant_id}
+                   'tenant_id': tenant_id}
             LOG.debug(emsg)
             raise exceptions.Invalid(error_message=emsg)
 
         if not os['projects'][tenant_id]:
             emsg = "tenant name(%(tenant_id)s) is empty" % {
-                       'tenant_id': tenant_id}
+                   'tenant_id': tenant_id}
             LOG.debug(emsg)
             raise exceptions.Invalid(error_message=emsg)
 
@@ -312,7 +312,7 @@ class Synchronizer(object):
             return network
         else:
             emsg = "network(%(network_id)s) is not found" % {
-                       'network_id': network_id}
+                   'network_id': network_id}
             LOG.debug(emsg)
             raise exceptions.Invalid(message=emsg)
 

--- a/networking_bigswitch_l3_pe/lib/synchronizer.py
+++ b/networking_bigswitch_l3_pe/lib/synchronizer.py
@@ -256,13 +256,13 @@ class Synchronizer(object):
             emsg = "subnet(%(subnet_id)s) doensn't have gateway_ip" % {
                        'subnet_id': subnet['id']}
             LOG.debug(emsg)
-            raise exceptions.Invalid(error_message=emsg)
+            raise exceptions.Invalid(message=emsg)
 
         if ('cidr' not in subnet) or (not subnet['cidr']):
             emsg = "subnet(%(subnet_id)s) doensn't have cidr" % {
                        'subnet_id': subnet['id']}
             LOG.debug(emsg)
-            raise exceptions.Invalid(error_message=emsg)
+            raise exceptions.Invalid(message=emsg)
 
         ip, mask = subnet['cidr'].split('/')
         if not mask:
@@ -271,7 +271,7 @@ class Synchronizer(object):
                        'cidr': subnet['cidr'],
                        'subnet_id': subnet['id']}
             LOG.debug(emsg)
-            raise exceptions.Invalid(error_message=emsg)
+            raise exceptions.Invalid(message=emsg)
 
         return subnet['gateway_ip'] + '/' + mask
 
@@ -280,13 +280,13 @@ class Synchronizer(object):
             emsg = "tenant(%(tenant_id)s) is not found" % {
                        'tenant_id': tenant_id}
             LOG.debug(emsg)
-            raise exceptions.Invalid(error_message=emsg)
+            raise exceptions.Invalid(message=emsg)
 
         if not os['projects'][tenant_id]:
             emsg = "tenant name(%(tenant_id)s) is empty" % {
                        'tenant_id': tenant_id}
             LOG.debug(emsg)
-            raise exceptions.Invalid(error_message=emsg)
+            raise exceptions.Invalid(message=emsg)
 
         return os['projects'][tenant_id] + '.' + self.neutron_id
 
@@ -314,7 +314,7 @@ class Synchronizer(object):
             emsg = "network(%(network_id)s) is not found" % {
                        'network_id': network_id}
             LOG.debug(emsg)
-            raise exceptions.Invalid(error_message=emsg)
+            raise exceptions.Invalid(message=emsg)
 
     def _add_resources(self, os, bcf):
         networks = []

--- a/networking_bigswitch_l3_pe/tests/unit/lib/test_rest_client.py
+++ b/networking_bigswitch_l3_pe/tests/unit/lib/test_rest_client.py
@@ -14,10 +14,10 @@
 
 from mock import Mock
 from mock import patch
-from neutron.tests import base
 import networking_bigswitch_l3_pe.lib.config
 from networking_bigswitch_l3_pe.lib.rest_client import BCFRestError
 from networking_bigswitch_l3_pe.lib.rest_client import RestClient
+from neutron.tests import base
 
 
 class RestClientTestCase(base.BaseTestCase):

--- a/networking_bigswitch_l3_pe/tests/unit/lib/test_rest_client.py
+++ b/networking_bigswitch_l3_pe/tests/unit/lib/test_rest_client.py
@@ -40,7 +40,6 @@ class RestClientTestCase(base.BaseTestCase):
         mock_urlopen.return_value = self._setup_mock(200, ['[]'])
         client = self._setup_rest_client()
 
-        client._renew_session()
         ret = client._get_segment_interface('tenant_test')
         self.assertEqual([], ret)
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,7 @@
+enum
+configparser
+extras
+pytz
 flake8
 testrepository
 oslo.config


### PR DESCRIPTION
When adding networks/subnets in OpenStack, this plugin causes topology sync by bsnstacklib. When the openstack environment has many projects, networks and instances, the topology sync takes long time.

This PR adds logic to synchronizes with BCF periodically to reduce the topology sync.